### PR TITLE
Custom role for Azure Policy, allows creation of resources without contributor access

### DIFF
--- a/components/custom_roles/role_definitions.yaml
+++ b/components/custom_roles/role_definitions.yaml
@@ -8,3 +8,13 @@
     not_actions:
     data_actions:
     not_data_actions:
+- name: Azure Policy Resource Group and Security Automation Creation
+  description: Allow Azure Policy MI to create resources
+  scope: "/providers/Microsoft.Management/managementGroups/HMCTS"
+  permissions:
+    actions:
+      - "Microsoft.Resources/subscriptions/resourceGroups/write"
+      - "Microsoft.Security/automations/write"
+    not_actions:
+    data_actions:
+    not_data_actions:

--- a/components/custom_roles/role_definitions.yaml
+++ b/components/custom_roles/role_definitions.yaml
@@ -8,13 +8,15 @@
     not_actions:
     data_actions:
     not_data_actions:
-- name: Azure Policy Resource Group and Security Automation Creation
+- name: Azure Policy Resource Group and Security Automation
   description: Allow Azure Policy MI to create resources
   scope: "/providers/Microsoft.Management/managementGroups/HMCTS"
   permissions:
     actions:
       - "Microsoft.Resources/subscriptions/resourceGroups/write"
+      - "Microsoft.Resources/subscriptions/resourceGroups/read"
       - "Microsoft.Security/automations/write"
+      - "Microsoft.Security/automations/read"
     not_actions:
     data_actions:
     not_data_actions:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-19515

### Change description

Custom role for Azure Policy, allows creation of resources without contributor access.
Specifically, resource groups and microsoft.security/automations.
Included read access so Azure Policy and audit these resources as well.
